### PR TITLE
Add Random::Splittable

### DIFF
--- a/spec/splittable_spec.cr
+++ b/spec/splittable_spec.cr
@@ -1,0 +1,63 @@
+require "./spec_helper"
+
+describe Random::Splittable do
+  it "#new" do
+    Random::Splittable.new(12345_u64) # okayish
+    Random::Splittable.new # preferred
+  end
+
+  it "#next_u" do
+    # test vectors generated using Vigna's C port of splitmix64 modified by
+    # Lemire. See https://github.com/lemire/testingRNG/blob/master/source/splitmix64.h
+    numbers = UInt64.static_array(
+      5395234354446855067_u64,
+      16021672434157553954_u64,
+      153047824787635229_u64,
+      8387618351419058064_u64,
+      4321915660117851420_u64,
+      12330924294077242175_u64,
+      6498654868697050547_u64,
+      12901208535622949722_u64,
+      761180149847513477_u64,
+      2787253749255891838_u64,
+      16301321118497315113_u64,
+      18121810407135723964_u64,
+      1996552940493526361_u64,
+      14953694261937354197_u64,
+      17733042562290725154_u64,
+      4838159024254620019_u64,
+      1408474051473620737_u64,
+      10752863733234826378_u64,
+      14227366121956509625_u64,
+      2021615829517336939_u64,
+    )
+    rng = Random::Splittable.new(0xdeadbeef_u64)
+    numbers.each do |expected|
+      rng.next_u.should eq(expected)
+    end
+  end
+
+  it "#next_int" do
+    rng = Random::Splittable.new(12345_u64)
+    rng.next_int.should eq(-1526108289)
+    rng.next_int.should eq(384012526)
+    rng.next_int.should eq(-422007946)
+  end
+
+  it "#next_float" do
+    rng = Random::Splittable.new(12345_u64)
+    rng.next_float.should eq(0.1330796686614273)
+    rng.next_float.should eq(0.20481663336165912)
+    rng.next_float.should eq(0.11954258300911547)
+  end
+
+  it "#split" do
+    rng = Random::Splittable.new(12345_u64)
+
+    rng = rng.split
+    rng.next_u.should eq(15328130456064710858_u64)
+
+    rng = rng.split
+    rng.next_u.should eq(9989932672924920245_u64)
+  end
+end

--- a/src/crystal-random/splittable.cr
+++ b/src/crystal-random/splittable.cr
@@ -1,0 +1,87 @@
+require "atomic"
+require "secure_random"
+
+# Splittable Random Number Generator
+#
+# Based on the original implementation of SplittableRandom found in the "Fast
+# Splittable Pseudorandom Number Generators" paper by Guy L. Steel, Doug Lea and
+# Christine Flood. See:
+# <https://www.researchgate.net/publication/273188325_Fast_Splittable_Pseudorandom_Number_Generators>.
+#
+# The original implementation was modified to match the SplittableRandom
+# generator found in Java 8 SDK, as well as Lemire's C port (based on Vigna's).
+# See: https://github.com/lemire/testingRNG/blob/master/source/splitmix64.h
+class Random::Splittable
+  include Random
+
+  # :nodoc:
+  GOLDEN_GAMMA = 0x9e3779b97f4a7c15_u64 # odd
+
+  # :nodoc:
+  DOUBLE_UNIT = 1.0 / (1_u64 << 53)
+
+  @seed : UInt64
+  @gamma : UInt64
+
+  def initialize
+    s = default_gen.add(2_u64 * GOLDEN_GAMMA)
+    @seed = mix64(s)
+    @gamma = mix_gamma(s + GOLDEN_GAMMA)
+  end
+
+  def initialize(@seed)
+    @gamma = GOLDEN_GAMMA
+  end
+
+  def initialize(@seed, @gamma)
+  end
+
+  def next_u : UInt64
+    mix64(next_seed)
+  end
+
+  def next_int : Int32
+    mix32(next_seed)
+  end
+
+  def next_float : Float64
+    (next_u >> 11) * DOUBLE_UNIT
+  end
+
+  def split : self
+    self.class.new(next_u, mix_gamma(next_seed))
+  end
+
+  private def next_seed
+    @seed += @gamma
+  end
+
+  private def mix64(z)
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9_u64
+    z = (z ^ (z >> 27)) * 0x94d049bb133111eb_u64
+    z ^ (z >> 31)
+  end
+
+  private def mix32(z)
+    z = (z ^ (z >> 33)) * 0x62a9d9ed799705f5_u64
+    (((z ^ (z >> 28)) * 0xcb24d0a5c88c35b3_u64) >> 32).to_i32
+  end
+
+  private def mix_gamma(z)
+    z = (z ^ (z >> 33)) * 0xff51afd7ed558ccd_u64
+    z = (z ^ (z >> 33)) * 0xc4ceb9fe1a85ec53_u64
+    z = (z ^ (z >> 33)) | 1_u64
+    n = (z ^ (z >> 1)).popcount
+    (n < 24) ? z ^ 0xaaaaaaaaaaaaaaaa_u64 : z
+  end
+
+  private def default_gen
+    @@default_gen ||= Atomic(UInt64).new(initial_seed)
+  end
+
+  private def initial_seed
+    bytes = uninitialized UInt8[8]
+    SecureRandom.random_bytes(bytes.to_slice)
+    bytes.to_unsafe.as(UInt64*).value
+  end
+end


### PR DESCRIPTION
Implements SplittableRandom (or splitmix64) as found in the [Fast Splittable Pseudorandom Number Generators](https://www.researchgate.net/publication/273188325_Fast_Splittable_Pseudorandom_Number_Generators) paper by Guy L. Steel, Doug Lea and Christine Flood; tweaked to match Java's SplittableRandom generator.

Splitmix64 is just a bit slower than xoroshiro128+, and passes PractRand and TestU01 in BigCrush mode —see [Lemire's test results](https://lemire.me/blog/2017/08/22/testing-non-cryptographic-random-number-generators-my-results/).

`Random::Splittable` takes a single UInt64 from `Random::System`, then each instance will split from this initial seed. The generator also features a `#split` method to manually split the generator at any time —read the paper for better understanding how splitting the generator is useful in concurrent contexts. Since instances derive their seed, initialization time is faster compared to other PRNG that will request a seed from `Random::System` each time.